### PR TITLE
use IO::Memory instead of MemoryIO to fix warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,9 @@ proto_io = File.read("path/to/encoded/protobuf") # get your IO in some way
 msg = MyMessage.from_protobuf(proto_io) # returns a an instance of MyMessage
                                   # from a valid protobuf encoded message
 
-msg.to_protobuf # return a MemoryIO filled with the encoded message
+msg.to_protobuf # return a IO::Memory filled with the encoded message
 
-some_io = MemoryIO.new
+some_io = IO::Memory.new
 msg.to_protobuf(some_io) # fills up the provided IO with the encoded message
 ```
 

--- a/src/enum.cr
+++ b/src/enum.cr
@@ -13,7 +13,7 @@ abstract struct Enum
   end
 
   def to_protobuf(embedded = true)
-    io = MemoryIO.new
+    io = IO::Memory.new
     to_protobuf(io, embedded)
   end
 end

--- a/src/protobuf/buffer.cr
+++ b/src/protobuf/buffer.cr
@@ -108,7 +108,7 @@ module Protobuf
     def new_from_length
       slice = read_bytes
       return nil if slice.nil?
-      Protobuf::Buffer.new MemoryIO.new(slice)
+      Protobuf::Buffer.new IO::Memory.new(slice)
     end
 
     def decode_zigzag(value)
@@ -208,7 +208,7 @@ module Protobuf
     end
 
     def write_packed(arr, pb_type)
-      io = MemoryIO.new
+      io = IO::Memory.new
       tmp_buf = self.class.new(io)
       arr.not_nil!.each {|i| tmp_buf.write(i, pb_type) }
       write_uint64(io.bytesize.to_u64)

--- a/src/protobuf/message.cr
+++ b/src/protobuf/message.cr
@@ -138,7 +138,7 @@ module Protobuf
 
     macro _generate_encoder
       def to_protobuf
-        io = MemoryIO.new
+        io = IO::Memory.new
         to_protobuf(io)
         io
       end


### PR DESCRIPTION
Hello,

Crystal renamed `MemoryIO` to `IO::Memory` in version **0.20**. Easy fix :)