### PR TITLE
fix read_bool so that it doesn't always return true

### DIFF
--- a/src/protobuf/buffer.cr
+++ b/src/protobuf/buffer.cr
@@ -102,7 +102,7 @@ module Protobuf
     end
 
     def read_bool
-      !!@io.read_byte
+      @io.read_byte == 1
     end
 
     def new_from_length


### PR DESCRIPTION
`!!0_u8`  is true