### PR TITLE
Initial proto3 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,3 @@
-# TEST Fork for proto3 compatibility work
-
-Use original at jeromeg/protobuf.cr
-
-
-
-
-
 # protobuf [![Build Status](https://travis-ci.org/jeromegn/protobuf.cr.svg?branch=master)](https://travis-ci.org/jeromegn/protobuf.cr) [![Dependency Status](https://shards.rocks/badge/github/jeromegn/protobuf.cr/status.svg)](https://shards.rocks/github/jeromegn/protobuf.cr) [![devDependency Status](https://shards.rocks/badge/github/jeromegn/protobuf.cr/dev_status.svg)](https://shards.rocks/github/jeromegn/protobuf.cr)
 
 Crystal shard to decode, encode and generate protobuf messages.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+# TEST Fork for proto3 compatibility work
+
+Use original at jeromeg/protobuf.cr
+
+
+
+
+
 # protobuf [![Build Status](https://travis-ci.org/jeromegn/protobuf.cr.svg?branch=master)](https://travis-ci.org/jeromegn/protobuf.cr) [![Dependency Status](https://shards.rocks/badge/github/jeromegn/protobuf.cr/status.svg)](https://shards.rocks/github/jeromegn/protobuf.cr) [![devDependency Status](https://shards.rocks/badge/github/jeromegn/protobuf.cr/dev_status.svg)](https://shards.rocks/github/jeromegn/protobuf.cr)
 
 Crystal shard to decode, encode and generate protobuf messages.

--- a/spec/fixtures/generated_proto2/Test1Message.pb.cr
+++ b/spec/fixtures/generated_proto2/Test1Message.pb.cr
@@ -1,0 +1,13 @@
+#require "protobuf"
+
+module TestMessagesProto2
+
+  struct Test1
+    include Protobuf::Message
+
+    contract do
+      required :a, :int32, 1
+    end
+  end
+
+end

--- a/spec/fixtures/generated_proto2/Test2Message.pb.cr
+++ b/spec/fixtures/generated_proto2/Test2Message.pb.cr
@@ -5,7 +5,7 @@ module TestMessagesProto2
   struct Test2
     include Protobuf::Message
 
-    contract do
+    contract_of "proto2" do
       required :b, :string, 2
     end
   end

--- a/spec/fixtures/generated_proto2/Test2Message.pb.cr
+++ b/spec/fixtures/generated_proto2/Test2Message.pb.cr
@@ -1,0 +1,12 @@
+#require "protobuf"
+
+module TestMessagesProto2
+
+  struct Test2
+    include Protobuf::Message
+
+    contract do
+      required :b, :string, 2
+    end
+  end
+  end

--- a/spec/fixtures/generated_proto2/Test3Message.pb.cr
+++ b/spec/fixtures/generated_proto2/Test3Message.pb.cr
@@ -1,0 +1,12 @@
+#require "protobuf"
+
+module TestMessagesProto2
+
+  struct Test3
+    include Protobuf::Message
+
+    contract do
+      required :c, Test1, 3
+    end
+  end
+  end

--- a/spec/fixtures/generated_proto2/Test4Message.pb.cr
+++ b/spec/fixtures/generated_proto2/Test4Message.pb.cr
@@ -1,0 +1,21 @@
+#require "protobuf"
+
+module TestMessagesProto2
+
+  struct Test4
+    include Protobuf::Message
+
+    contract do
+      repeated :d, :int32, 4
+    end
+  end
+
+  struct Test4Packed
+    include Protobuf::Message
+
+    contract do
+      repeated :d, :int32, 4, packed: true
+    end
+  end
+
+end

--- a/spec/fixtures/generated_proto3/Test1Message3.pb.cr
+++ b/spec/fixtures/generated_proto3/Test1Message3.pb.cr
@@ -6,7 +6,7 @@ module TestMessagesProto3
   struct Test1
     include Protobuf::Message
 
-    contract do
+    contract_of "proto3" do
       optional :a, :int32, 1
     end
   end

--- a/spec/fixtures/generated_proto3/Test1Message3.pb.cr
+++ b/spec/fixtures/generated_proto3/Test1Message3.pb.cr
@@ -1,0 +1,14 @@
+## Generated from Test1Message3.proto for com.acme.proto3
+#require "protobuf"
+
+module TestMessagesProto3
+
+  struct Test1
+    include Protobuf::Message
+
+    contract do
+      optional :a, :int32, 1
+    end
+  end
+
+end

--- a/spec/fixtures/generated_proto3/Test2Message3.pb.cr
+++ b/spec/fixtures/generated_proto3/Test2Message3.pb.cr
@@ -6,7 +6,7 @@ module TestMessagesProto3
   struct Test2
     include Protobuf::Message
 
-    contract do
+    contract_of "proto3" do
       optional :b, :string, 2
     end
   end

--- a/spec/fixtures/generated_proto3/Test2Message3.pb.cr
+++ b/spec/fixtures/generated_proto3/Test2Message3.pb.cr
@@ -1,0 +1,13 @@
+## Generated from Test2Message3.proto for com.acme.proto3
+#require "protobuf"
+
+module TestMessagesProto3
+
+  struct Test2
+    include Protobuf::Message
+
+    contract do
+      optional :b, :string, 2
+    end
+  end
+end

--- a/spec/fixtures/generated_proto3/Test3Message3.pb.cr
+++ b/spec/fixtures/generated_proto3/Test3Message3.pb.cr
@@ -6,7 +6,7 @@ module TestMessagesProto3
   struct Test3
     include Protobuf::Message
 
-    contract do
+    contract_of "proto3" do
       optional :c, Test1, 3
     end
   end

--- a/spec/fixtures/generated_proto3/Test3Message3.pb.cr
+++ b/spec/fixtures/generated_proto3/Test3Message3.pb.cr
@@ -1,0 +1,13 @@
+## Generated from Test3Message3.proto for com.acme.proto3
+#require "protobuf"
+
+module TestMessagesProto3
+
+  struct Test3
+    include Protobuf::Message
+
+    contract do
+      optional :c, Test1, 3
+    end
+  end
+end

--- a/spec/fixtures/generated_proto3/Test4Message3.pb.cr
+++ b/spec/fixtures/generated_proto3/Test4Message3.pb.cr
@@ -6,7 +6,7 @@ module TestMessagesProto3
   struct Test4
     include Protobuf::Message
 
-    contract3 do
+    contract_of "proto3" do
       repeated :d, :int32, 4
     end
   end

--- a/spec/fixtures/generated_proto3/Test4Message3.pb.cr
+++ b/spec/fixtures/generated_proto3/Test4Message3.pb.cr
@@ -1,0 +1,14 @@
+## Generated from Test4Message3.proto for com.acme.proto3
+#require "protobuf"
+
+module TestMessagesProto3
+
+  struct Test4
+    include Protobuf::Message
+
+    contract3 do
+      repeated :d, :int32, 4
+    end
+  end
+
+end

--- a/spec/protobuf/encexamples_spec.cr
+++ b/spec/protobuf/encexamples_spec.cr
@@ -1,0 +1,85 @@
+require "../spec_helper"
+
+# Encoding tests for simple examples on
+# https://developers.google.com/protocol-buffers/docs/encoding
+
+require "../fixtures/generated_proto3/*"
+require "../fixtures/generated_proto2/*"
+
+def msg_to_protobuf_hexstring(msg : Protobuf::Message)
+  some_io = IO::Memory.new
+  msg.to_protobuf some_io
+  some_io.to_slice.hexstring
+end
+
+# Proto3
+describe "Protobuf::Message" do
+  it "V3 encodes varint Test1" do
+    msg = TestMessagesProto3::Test1.new
+    msg.a=150
+    str = msg_to_protobuf_hexstring msg
+    str.should eq "089601"
+  end
+
+  it "V3 encodes length-encoded string Test2" do
+    msg = TestMessagesProto3::Test2.new
+    msg.b = "testing"
+    str = msg_to_protobuf_hexstring msg
+    str.should eq "120774657374696e67"
+  end
+
+  it "V3 encodes included type Test3" do
+    msg1 = TestMessagesProto3::Test1.new
+    msg1.a=150
+    msg = TestMessagesProto3::Test3.new
+    msg.c=msg1
+    str = msg_to_protobuf_hexstring msg
+    str.should eq "1a03089601"
+  end
+
+  it "V3 encodes repeated (packed by default) Test4" do
+    msg = TestMessagesProto3::Test4.new
+    msg.d = [ 3,270, 86942]
+    str = msg_to_protobuf_hexstring msg
+
+    str.should eq "2206038e029ea705"
+  end
+end
+
+# Proto2
+describe "Protobuf::Message V2" do
+  it "encodes varint Test1" do
+    msg = TestMessagesProto2::Test1.new 150
+    str = msg_to_protobuf_hexstring msg
+    str.should eq "089601"
+  end
+
+  it "encodes length-encoded string Test2" do
+    msg = TestMessagesProto2::Test2.new "testing"
+    str = msg_to_protobuf_hexstring msg
+    str.should eq "120774657374696e67"
+  end
+
+  it "encodes included type Test3" do
+    msg1 = TestMessagesProto2::Test1.new 150
+    msg = TestMessagesProto2::Test3.new msg1
+    str = msg_to_protobuf_hexstring msg
+    str.should eq "1a03089601"
+  end
+
+  it "encodes repeated Test4" do
+    msg = TestMessagesProto2::Test4.new
+    msg.d = [ 3,270, 86942]
+    str = msg_to_protobuf_hexstring msg
+
+    str.should eq "2003208e02209ea705" # unpacked
+  end
+
+  it "encodes repeated Test4 Packed" do
+    msg = TestMessagesProto2::Test4Packed.new
+    msg.d = [ 3,270, 86942]
+    str = msg_to_protobuf_hexstring msg
+
+    str.should eq "2206038e029ea705"  # packed
+  end
+end

--- a/src/protobuf/generator.cr
+++ b/src/protobuf/generator.cr
@@ -1,3 +1,9 @@
+#NOTE: all descriptors defined here are derived from
+# https://github.com/google/protobuf/blob/master/src/google/protobuf/compiler/plugin.proto
+#
+# The protoc binary will pass a CodeGeneratorRequest in binary format to plugins
+# via STDIN and expect an encoded CodeGeneratorResponse on STDOUT
+
 module Protobuf
   struct CodeGeneratorRequest
     include Protobuf::Message
@@ -121,6 +127,8 @@ module Protobuf
 
         repeated :message_type, CodeGeneratorRequest::DescriptorProto,     4;
         repeated :enum_type,    CodeGeneratorRequest::EnumDescriptorProto, 5;
+
+        optional :syntax, :string, 12    # proto2 or proto3
       end
 
       def crystal_ns
@@ -139,6 +147,7 @@ module Protobuf
       optional :parameter, :string, 2
 
       repeated :proto_file, CodeGeneratorRequest::FileDescriptorProto, 15
+
     end
   end
 
@@ -237,7 +246,13 @@ module Protobuf
         message_type.enum_type.not_nil!.each { |et| enum!(et) } unless message_type.enum_type.nil?
         message_type.nested_type.not_nil!.each { |mt| message!(mt) } unless message_type.nested_type.nil?
         puts nil
-        puts "contract do"
+
+        # use contract3() macro for proto3, otherwise use contract() macro
+
+        syntaxChar = ""
+        syntaxChar = "3" unless @file.syntax.nil? || @file.syntax != "proto3"
+
+        puts "contract#{syntaxChar} do"
         indent do
           message_type.field.not_nil!.each { |f| field!(f) } unless message_type.field.nil?
         end

--- a/src/protobuf/generator.cr
+++ b/src/protobuf/generator.cr
@@ -249,10 +249,9 @@ module Protobuf
 
         # use contract3() macro for proto3, otherwise use contract() macro
 
-        syntaxChar = ""
-        syntaxChar = "3" unless @file.syntax.nil? || @file.syntax != "proto3"
+        syntax = @file.syntax.nil? ? "proto2" : @file.syntax
 
-        puts "contract#{syntaxChar} do"
+        puts "contract_of \"#{syntax}\" do"
         indent do
           message_type.field.not_nil!.each { |f| field!(f) } unless message_type.field.nil?
         end

--- a/src/protobuf/message.cr
+++ b/src/protobuf/message.cr
@@ -3,16 +3,16 @@ module Protobuf
     macro contract
       FIELDS = {} of Int32 => HashLiteral(Symbol, ASTNode)
       {{yield}}
-      _generate_decoder 2
-      _generate_encoder 2
+      _generate_decoder "proto2"
+      _generate_encoder "proto2"
       _generate_getters_setters
     end
 
-    macro contract3
+    macro contract_of (syntax, &blk)
       FIELDS = {} of Int32 => HashLiteral(Symbol, ASTNode)
       {{yield}}
-      _generate_decoder 3
-      _generate_encoder 3
+      _generate_decoder {{syntax}}
+      _generate_encoder {{syntax}}
       _generate_getters_setters
     end
 
@@ -71,7 +71,7 @@ module Protobuf
             %}
             {% if field[:repeated] %}\
               %var{tag} ||= [] of {{field[:crystal_type]}}
-              {% if pbVer >= 3 || field[:packed] %}
+              {% if pbVer != "proto2" || field[:packed] %}
                 packed_buf_{{tag}} = buf.new_from_length.not_nil!
                 loop do
                   %packed_var{tag} = {{(!!pb_type ? "packed_buf_#{tag}.read_#{field[:pb_type].id}" : "#{field[:crystal_type]}.new(packed_buf_#{tag})").id}}
@@ -165,7 +165,7 @@ module Protobuf
           {% if field[:optional] %}
             if !@{{field[:name].id}}.nil?
               {% if field[:repeated] %}
-                {% if pbVer >= 3 || field[:packed] %}
+                {% if pbVer != "proto2" || field[:packed] %}
                   buf.write_info({{tag}}, 2)
                   buf.write_packed(@{{field[:name].id}}, {{field[:pb_type]}})
                 {% else %}

--- a/src/protobuf/message.cr
+++ b/src/protobuf/message.cr
@@ -1,12 +1,5 @@
 module Protobuf
   module Message
-    macro contract
-      FIELDS = {} of Int32 => HashLiteral(Symbol, ASTNode)
-      {{yield}}
-      _generate_decoder "proto2"
-      _generate_encoder "proto2"
-      _generate_getters_setters
-    end
 
     macro contract_of (syntax, &blk)
       FIELDS = {} of Int32 => HashLiteral(Symbol, ASTNode)
@@ -14,6 +7,10 @@ module Protobuf
       _generate_decoder {{syntax}}
       _generate_encoder {{syntax}}
       _generate_getters_setters
+    end
+
+    macro contract(&blk)
+      contract_of "proto2" {{blk}}
     end
 
     macro _add_field(tag, name, pb_type, options = {} of Symbol => Bool)


### PR DESCRIPTION
Sorry, didn't squash commits.  Changes:
 - Add syntax field to FileDescriptorProto def
 - add Message.contract_of(syntax)
 - Message._generate_encoder macro now takes syntax string param
 - Message._generate_decoder macro now takes syntax string param
 - Message.contract() macro passes "proto2" to generate_encoder/decoder
 - In generator, use contract_of (@file.syntax) macro
 - generate_encoder/generate_decoder macros will default to packed for repeated fields when syntax != "proto2"
 - Added more Encoding specs based on docs.