### PR TITLE
added `Protobuf::Message#[](key)`

### DIFF
--- a/spec/protobuf/hash_access_spec.cr
+++ b/spec/protobuf/hash_access_spec.cr
@@ -1,0 +1,27 @@
+require "../spec_helper"
+
+require "../fixtures/test.pb"
+
+describe Protobuf::Message do
+  describe "#[key]" do
+    context "when the key is a member" do
+      it "acts as #key" do
+        File.open("#{__DIR__}/../fixtures/test.data.encoded") do |io|
+          test = Test.from_protobuf(io)
+          test["f1"].should eq("dsfadsafsaf")
+        end
+      end
+    end
+
+    context "when the key is not a member" do
+      it "raises a runtime error" do
+        File.open("#{__DIR__}/../fixtures/test.data.encoded") do |io|
+          test = Test.from_protobuf(io)
+          expect_raises(Protobuf::Error, /Field not found/) do
+            test["XX"]
+          end
+        end
+      end
+    end
+  end
+end

--- a/src/protobuf/message.cr
+++ b/src/protobuf/message.cr
@@ -7,6 +7,7 @@ module Protobuf
       _generate_decoder {{syntax}}
       _generate_encoder {{syntax}}
       _generate_getters_setters
+      _generate_hash_getters
     end
 
     macro contract(&blk)
@@ -192,6 +193,18 @@ module Protobuf
       {% for tag, field in FIELDS %}
         property {{field[:name].id}} : {{field[:cast_type]}}
       {% end %}
+    end
+
+    macro _generate_hash_getters
+      def [](key : String)
+        case key
+        {% for tag, field in FIELDS %}
+          when {{field[:name].id.stringify}} ; self.{{field[:name].id}}
+        {% end %}
+        else
+          raise Protobuf::Error.new("Field not found: `#{key}`")
+        end
+      end
     end
 
     def ==(other : Protobuf::Message)


### PR DESCRIPTION
This provides Hash like accessors.

```crystal
test = Test.from_protobuf(io)
test.f1    # => "dsfadsafsaf"
test["f1"] # => "dsfadsafsaf"

test["XX"] # raises "Field not found: `XX`"
```

Thanks.
