### PR TITLE
accept an empty list for repeated fields

### DIFF
--- a/spec/protobuf/message_spec.cr
+++ b/spec/protobuf/message_spec.cr
@@ -54,4 +54,9 @@ describe Protobuf::Message do
       test.should eq(test2) # OMG
     end
   end
+
+  it "encodes empty-list as repeated" do
+    test4 = TestMessagesProto2::Test4.new(d: [] of Int32)
+    test4.to_protobuf.empty?.should be_true
+  end
 end

--- a/src/protobuf/message.cr
+++ b/src/protobuf/message.cr
@@ -154,7 +154,7 @@ module Protobuf
         buf = Protobuf::Buffer.new(io)
         {% for tag, field in FIELDS %}
           %val{tag} = @{{field[:name].id}}
-          %is_enum{tag} = %val{tag}.is_a?(Enum) || %val{tag}.is_a?(Array) && %val{tag}.first.is_a?(Enum)
+          %is_enum{tag} = %val{tag}.is_a?(Enum) || %val{tag}.is_a?(Array) && %val{tag}.first?.is_a?(Enum)
           %wire{tag} = Protobuf::WIRE_TYPES.fetch({{field[:pb_type]}}, %is_enum{tag} ? 0 : 2)
           {%
             pb_type = Protobuf::PB_TYPE_MAP[field[:pb_type]]


### PR DESCRIPTION
This fixes the following corner case where an empty list is given for `repeated` fields. 

```crystal
struct Foo
  include Protobuf::Message
  contract_of "proto2" do
    repeated :nums, :int32, 1
  end
end

pb = Foo.new([] of Int32)
pb.to_protobuf  #        Index out of bounds
```

Best regards,