### PR TITLE
Add JSON mappings to generated containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,15 +56,17 @@ struct MyMessage
   # write your methods like you normally would here, if you like.
 end
 
-proto_io = File.read("path/to/encoded/protobuf") # get your IO in some way
+msg = MyMessage.new prop_name = 42, prop2 = Foo::FOO, optional_prop_name = "Foo" # create a struct as usual
+puts "Before serializing: #{msg}"
 
-msg = MyMessage.from_protobuf(proto_io) # returns a an instance of MyMessage
-                                  # from a valid protobuf encoded message
+io = IO::Memory.new
+msg.to_protobuf(io) # write the protobuf message to IO (could also be a File, network etc)
 
-msg.to_protobuf # return a IO::Memory filled with the encoded message
+io.pos = 0 # Seek back to the start of the IO::Memory ready for reading
 
-some_io = IO::Memory.new
-msg.to_protobuf(some_io) # fills up the provided IO with the encoded message
+decoded = MyMessage.from_protobuf(io) # returns an instance of MyMessage from a valid protobuf encoded message
+
+puts "After serializing: #{decoded}"
 ```
 
 #### Field types

--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ Example:
 
 ```crystal
 require "protobuf"
-require "tempfile"
 
 enum Foo
   FOO
@@ -57,23 +56,15 @@ struct MyMessage
   # write your methods like you normally would here, if you like.
 end
 
-# MyMessage is just a normal struct - let's create one
-msg = MyMessage.new prop_name: 42, prop2: Foo::FOO, optional_prop_name: "Bar"
-puts "Before serialization: #{msg}"
+proto_io = File.read("path/to/encoded/protobuf") # get your IO in some way
 
-io_memory = msg.to_protobuf # io_memory is an IO::Memory of the encoded message
+msg = MyMessage.from_protobuf(proto_io) # returns a an instance of MyMessage
+                                  # from a valid protobuf encoded message
 
-# Or write the encoded message into any IO object - such as network, or a file
-tmpfile = Tempfile.open("my_message") do |output_file| 
-    msg.to_protobuf output_file # In this case we use a temporary file
-end
+msg.to_protobuf # return a IO::Memory filled with the encoded message
 
-# Now let's decode the message...
-input_file = File.open(tmpfile.path) # open an IO object (the file we just wrote)
-decoded_msg = MyMessage.from_protobuf(input_file) # return an instance of MyMessage
-
-puts "After serialization: #{decoded_msg}"
-tmpfile.delete # clean up the temporary file
+some_io = IO::Memory.new
+msg.to_protobuf(some_io) # fills up the provided IO with the encoded message
 ```
 
 #### Field types

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Example:
 
 ```crystal
 require "protobuf"
+require "tempfile"
 
 enum Foo
   FOO

--- a/README.md
+++ b/README.md
@@ -56,17 +56,23 @@ struct MyMessage
   # write your methods like you normally would here, if you like.
 end
 
-msg = MyMessage.new prop_name = 42, prop2 = Foo::FOO, optional_prop_name = "Foo" # create a struct as usual
-puts "Before serializing: #{msg}"
+# MyMessage is just a normal struct - let's create one
+msg = MyMessage.new prop_name: 42, prop2: Foo::FOO, optional_prop_name: "Bar"
+puts "Before serialization: #{msg}"
 
-io = IO::Memory.new
-msg.to_protobuf(io) # write the protobuf message to IO (could also be a File, network etc)
+io_memory = msg.to_protobuf # io_memory is an IO::Memory of the encoded message
 
-io.pos = 0 # Seek back to the start of the IO::Memory ready for reading
+# Or write the encoded message into any IO object - such as network, or a file
+tmpfile = Tempfile.open("my_message") do |output_file| 
+    msg.to_protobuf output_file # In this case we use a temporary file
+end
 
-decoded = MyMessage.from_protobuf(io) # returns an instance of MyMessage from a valid protobuf encoded message
+# Now let's decode the message...
+input_file = File.open(tmpfile.path) # open an IO object (the file we just wrote)
+decoded_msg = MyMessage.from_protobuf(input_file) # return an instance of MyMessage
 
-puts "After serializing: #{decoded}"
+puts "After serialization: #{decoded_msg}"
+tmpfile.delete # clean up the temporary file
 ```
 
 #### Field types


### PR DESCRIPTION
Annotate the generated structs/classes with JSON mapping statements using the protobuf canonical format. This enables use of the to_json/from_json methods. This is a first pass - in particular, the type_name could do with refactoring out as there's a lot in common with the protobuf version. The default handling is not yet implemented for proto2 but that should be fairly trivial. The environment flag may need to be renamed as well for better consistency.

This feature could be considered outside scope for the library, but it may be useful for several use cases (mine is routes which accept either protobuf or json data).

Usage looks like:

```PROTOBUF_JSON=1 protoc --crystal_out=. hello.proto```

```proto
// hello.proto
syntax = "proto3";
import "google/protobuf/timestamp.proto";

message Hello {
  google.protobuf.Timestamp ts = 1;
  int32 foo = 2;
  repeated string fooBar = 3;
}
```

```
## Generated from google/protobuf/timestamp.proto for google.protobuf
require "protobuf"
require "json"


struct Timestamp
  include Protobuf::Message
  
  contract_of "proto3" do
    optional :seconds, :int64, 1
    optional :nanos, :int32, 2
  end
  
  JSON.mapping({
    seconds: {type: Int64, nilable: true, key: "seconds"},
    nanos: {type: Int32, nilable: true, key: "nanos"},
  })
end
```

```
## Generated from hello.proto
require "protobuf"
require "json"


struct Hello
  include Protobuf::Message
  
  contract_of "proto3" do
    optional :ts, Timestamp, 1
    optional :foo, :int32, 2
    repeated :foo_bar, :string, 3
  end
  
  JSON.mapping({
    ts: {type: Timestamp, nilable: true, key: "ts"},
    foo: {type: Int32, nilable: true, key: "foo"},
    foo_bar: {type: Array(String), nilable: true, key: "fooBar"},
  })
end
```