### PR TITLE
fix hash access when class has no fields

### DIFF
--- a/spec/fixtures/test.pb.cr
+++ b/spec/fixtures/test.pb.cr
@@ -44,6 +44,13 @@ enum SomeEnum
   NEVER = 3
 end
 
+class EmptyMessage
+  include Protobuf::Message
+
+  contract do
+  end
+end
+
 # extend Test {
 #     optional bool gtt = 100;
 #     optional double gtg = 101;

--- a/spec/protobuf/hash_access_spec.cr
+++ b/spec/protobuf/hash_access_spec.cr
@@ -13,6 +13,13 @@ describe Protobuf::Message do
       end
     end
 
+    it "works if no fields" do
+      empty = EmptyMessage.new
+      expect_raises(Protobuf::Error, /Field not found/) do
+        empty["blah"]
+      end
+    end
+
     context "when the key is not a member" do
       it "raises a runtime error" do
         File.open("#{__DIR__}/../fixtures/test.data.encoded") do |io|

--- a/src/protobuf/message.cr
+++ b/src/protobuf/message.cr
@@ -197,13 +197,11 @@ module Protobuf
 
     macro _generate_hash_getters
       def [](key : String)
-        case key
         {% for tag, field in FIELDS %}
-          when {{field[:name].id.stringify}} ; self.{{field[:name].id}}
+          return self.{{field[:name].id}} if {{field[:name].id.stringify}} == key
         {% end %}
-        else
-          raise Protobuf::Error.new("Field not found: `#{key}`")
-        end
+
+        raise Protobuf::Error.new("Field not found: `#{key}`")
       end
     end
 


### PR DESCRIPTION
Fixes a compile error as the macro couldn't expand if the class had no fields