### PR TITLE
added `Protobuf::Message#[]=(key,val)`, `Protobuf::Message#to_hash`

### DIFF
--- a/spec/protobuf/hash_access_spec.cr
+++ b/spec/protobuf/hash_access_spec.cr
@@ -31,4 +31,81 @@ describe Protobuf::Message do
       end
     end
   end
+
+  describe "#[key]=(val)" do
+    context "when the key is a member and the val type is valid" do
+      it "acts as #key=" do
+        File.open("#{__DIR__}/../fixtures/test.data.encoded") do |io|
+          test = Test.from_protobuf(io)
+          test["f1"] = "foo"
+          test["f1"].should eq("foo")
+          test.f1.should eq("foo")
+
+          test["f2"] = -1_i64
+          test["f2"].should eq(-1_i64)
+          test.f2.should eq(-1_i64)
+        end
+      end
+    end
+
+    context "when the key is a member but the val type is mismatch" do
+      it "raises ArgumentError" do
+        File.open("#{__DIR__}/../fixtures/test.data.encoded") do |io|
+          test = Test.from_protobuf(io)
+          expect_raises(ArgumentError, "f1 expected `String`, but got `Int32`") do
+            test["f1"] = 2
+          end
+
+          expect_raises(ArgumentError, "f2 expected `Int64`, but got `String`") do
+            test["f2"] = "foo"
+          end
+        end
+      end
+    end
+
+    context "when the key is not a member" do
+      it "raises a runtime error" do
+        File.open("#{__DIR__}/../fixtures/test.data.encoded") do |io|
+          test = Test.from_protobuf(io)
+          expect_raises(Protobuf::Error, /Field not found/) do
+            test["XX"] = nil
+          end
+        end
+      end
+
+      it "works if no fields" do
+        empty = EmptyMessage.new
+        expect_raises(Protobuf::Error, /Field not found/) do
+          empty["XX"] = nil
+        end
+      end
+    end
+  end
+
+  describe "#to_hash" do
+    it "returns a Hash(String, _)" do
+      File.open("#{__DIR__}/../fixtures/test.data.encoded") do |io|
+        test = Test.from_protobuf(io)
+        hash = test.to_hash
+
+        hash.is_a?(Hash).should be_true
+
+        # sample testing
+        hash.select{|k,v| k =~ /^f[12]$/}.should eq({"f1" => "dsfadsafsaf", "f2" => 234})
+
+        # ensures that both hash and pb have same values for all keys
+        hash.keys.each do |k|
+          hash[k].should eq(test[k])
+        end
+      end
+    end
+
+    it "works if no fields" do
+      empty = EmptyMessage.new
+      hash = empty.to_hash
+
+      hash.is_a?(Hash).should be_true
+      hash.empty?.should be_true
+    end
+  end
 end


### PR DESCRIPTION
This PR adds `#[]=` and `#to_hash` those provide runtime meta programming.

#### usecase of `[]=` 

```crystal
module Protobuf::Message
  def merge(hash)
    hash.each do |k,v|
      self[k] = v
...
```

#### usecase of `to_hash` 

```crystal
require "json"

struct User
  include Protobuf::Message
  contract_of "proto2" do
    required :user    , :string, 1
    optional :password, :string, 2
  end
end

record FilterParameter, keys : Array(String) do
  def apply(hash)
    hash.dup.tap{|h|
      keys.each{|k| h[k] = "[FILTERED]" if h.has_key?(k)}
    }
  end
end
```

```crystal
pb = User.new("maiha", "1234")
pb.to_hash         # => {"user" => "maiha", "password" => "1234"}
pb.to_hash.to_json # => {"user":"maiha","password":"1234"}

secure = FilterParameter.new(["password"])
secure.apply(pb.to_hash) # => {"user" => "maiha", "password" => "[FILTERED]"}
```

Best regards,
