### PR TITLE
.to_protobuf returns `Bytes` instead of `IO::Memory`.

### DIFF
--- a/spec/protobuf/message_spec.cr
+++ b/spec/protobuf/message_spec.cr
@@ -50,7 +50,7 @@ describe Protobuf::Message do
     File.open("#{__DIR__}/../fixtures/test.data.encoded") do |io|
       test = Test.from_protobuf(io)
       encoded = test.to_protobuf
-      test2 = Test.from_protobuf(encoded.rewind)
+      test2 = Test.from_protobuf(encoded)
       test.should eq(test2) # OMG
     end
   end

--- a/src/enum.cr
+++ b/src/enum.cr
@@ -7,6 +7,11 @@ abstract struct Enum
     new(Protobuf::Buffer.new(io))
   end
 
+  def self.from_protobuf(buf : Bytes)
+    io = IO::Memory.new buf
+    from_protobuf io
+  end
+
   def to_protobuf(io : IO, embedded = true)
     buf = Protobuf::Buffer.new(io)
     buf.write_uint64(self.to_i.to_u64)

--- a/src/protobuf/buffer.cr
+++ b/src/protobuf/buffer.cr
@@ -3,6 +3,10 @@ module Protobuf
     def initialize(@io : IO)
     end
 
+    def initialize(buf : Bytes)
+      @io = IO::Memory.new buf
+    end
+
     def skip(wire)
       case wire
       when 0 then read_uint64
@@ -216,9 +220,10 @@ module Protobuf
     end
 
     def write_message(msg : Protobuf::Message)
-      io = msg.to_protobuf
-      write_uint64(io.bytesize.to_u64)
-      write_io(io.rewind)
+      buf = msg.to_protobuf
+      io = IO::Memory.new buf
+      write_uint64(buf.bytesize.to_u64)
+      write_io(io)
     end
 
     def write_message(e : Enum)

--- a/src/protobuf/message.cr
+++ b/src/protobuf/message.cr
@@ -144,10 +144,10 @@ module Protobuf
     end
 
     macro _generate_encoder(pbVer)
-      def to_protobuf
+      def to_protobuf : Bytes
         io = IO::Memory.new
         to_protobuf(io)
-        io
+        io.to_slice
       end
 
       def to_protobuf(io : IO, embedded = false)


### PR DESCRIPTION
.from_protobuf accepts `Bytes`.