### PR TITLE
Proto3 fixes

### DIFF
--- a/spec/protobuf/buffer_spec.cr
+++ b/spec/protobuf/buffer_spec.cr
@@ -6,6 +6,11 @@ describe Protobuf::Buffer do
       buf = Protobuf::Buffer.new(io)
 
       # f1: "dsfadsafsaf"
+      5.times do
+        buf.peek_info.should eq({1, 2})
+      end
+
+      # f1: "dsfadsafsaf"
       buf.read_info.should eq({1, 2})
       buf.read_string.should eq("dsfadsafsaf")
 

--- a/src/protobuf/buffer.cr
+++ b/src/protobuf/buffer.cr
@@ -14,14 +14,14 @@ module Protobuf
 
     def read_uint64(peek=false)
       n = shift = 0_u64
-      pos = @io.pos
+      pos = @io.pos if peek
       loop do
         if shift >= 64
           raise Error.new("buffer overflow varint")
         end
         byte = @io.read_byte
         if byte.nil?
-          @io.pos = pos if peek
+          @io.pos = pos.not_nil! if peek
           return nil
         end
         b = byte.unsafe_chr.ord
@@ -29,7 +29,7 @@ module Protobuf
         n |= ((b & 0x7F).to_u64 << shift)
         shift += 7
         if (b & 0x80) == 0
-          @io.pos = pos if peek
+          @io.pos = pos.not_nil! if peek
           return n.to_u64
         end
       end

--- a/src/protobuf/buffer.cr
+++ b/src/protobuf/buffer.cr
@@ -210,7 +210,13 @@ module Protobuf
     def write_packed(arr, pb_type)
       io = IO::Memory.new
       tmp_buf = self.class.new(io)
-      arr.not_nil!.each {|i| tmp_buf.write(i, pb_type) }
+      arr.not_nil!.each do |i|
+        if i.responds_to? :to_protobuf
+          i.to_protobuf(io)
+        else
+          tmp_buf.write(i, pb_type)
+        end
+      end
       write_uint64(io.bytesize.to_u64)
       write_io(io.rewind)
     end

--- a/src/protobuf/message.cr
+++ b/src/protobuf/message.cr
@@ -75,6 +75,11 @@ module Protobuf
                   %packed_var{tag} = {{(!!pb_type ? "packed_buf_#{tag}.read_#{field[:pb_type].id}" : "#{field[:crystal_type]}.new(packed_buf_#{tag})").id}}
                   break if %packed_var{tag}.nil?
                   %var{tag} << %packed_var{tag}
+
+                  next_tag, _ = packed_buf_{{tag}}.peek_info
+                  if next_tag.nil?
+                    break
+                  end
                 end
               {% else %}
                 {% if !field[:native] %}


### PR DESCRIPTION
Working on getting proto3 working with repeated custom classes.

Fixes #23

```
syntax = "proto3";

message Hello {
  int32 foo = 1;
  repeated HelloInner inners = 2;
  repeated int32 inners2 = 3;
}

message HelloInner {
  int32 inner_foo = 1;
}
```

Tested with:

`CAISAggqGgN7yAM=` (produced by crystal)
`CAISAggqGHsYyAM=` (produced by ruby)

Need to figure out why they are different.