### PR TITLE
Improve `oneof` support

### DIFF
--- a/spec/fixtures/generated_proto2/TestOneofMessage.pb.cr
+++ b/spec/fixtures/generated_proto2/TestOneofMessage.pb.cr
@@ -1,0 +1,25 @@
+#require "protobuf"
+
+module TestMessagesProto2
+
+  struct TestOneof1
+    include Protobuf::Message
+
+    contract do
+      optional :a, :int32, 1
+
+      optional :oo0_a, :int32, 2, oneof_index: 0
+      optional :oo0_b, :int32, 3, oneof_index: 0
+      optional :oo0_c, :int32, 4, oneof_index: 0
+
+      optional :b, :int32, 5
+
+      optional :oo1_a, :int32, 6, oneof_index: 1
+      optional :oo1_b, :int32, 7, oneof_index: 1
+      optional :oo1_c, :int32, 8, oneof_index: 1
+
+      oneof 0, "oo0"
+      oneof 1, "oo1"
+    end
+  end
+end

--- a/spec/fixtures/generated_proto3/TestOneofMessage.pb.cr
+++ b/spec/fixtures/generated_proto3/TestOneofMessage.pb.cr
@@ -1,0 +1,25 @@
+#require "protobuf"
+
+module TestMessagesProto3
+
+  struct TestOneof1
+    include Protobuf::Message
+
+    contract do
+      optional :a, :int32, 1
+
+      optional :oo0_a, :int32, 2, oneof_index: 0
+      optional :oo0_b, :int32, 3, oneof_index: 0
+      optional :oo0_c, :int32, 4, oneof_index: 0
+
+      optional :b, :int32, 5
+
+      optional :oo1_a, :int32, 6, oneof_index: 1
+      optional :oo1_b, :int32, 7, oneof_index: 1
+      optional :oo1_c, :int32, 8, oneof_index: 1
+
+      oneof 0, "oo0"
+      oneof 1, "oo1"
+    end
+  end
+end

--- a/spec/fixtures/test.pb.cr
+++ b/spec/fixtures/test.pb.cr
@@ -15,7 +15,9 @@ struct Test
     required :sint64, :sint64, 13
     required :bool, :bool, 14
 
-    repeated :enum, SomeEnum, 15
+    # "enum" is a reserved keyword in
+    # crystal so we use "my_enum" for this one
+    repeated :my_enum, SomeEnum, 15
 
     required :fixed64, :fixed64, 16
     required :sfixed64, :sfixed64, 17

--- a/spec/fixtures/test3.pb.cr
+++ b/spec/fixtures/test3.pb.cr
@@ -25,7 +25,7 @@ module TestMessagesV3
       optional :sint32, :sint32, 12
       optional :sint64, :sint64, 13
       optional :bool_e, :bool, 14
-      repeated :enum, SomeEnum, 15
+      repeated :my_enum, SomeEnum, 15
       optional :fixed64, :fixed64, 16
       optional :sfixed64, :sfixed64, 17
       optional :double, :double, 18

--- a/src/protobuf/generator.cr
+++ b/src/protobuf/generator.cr
@@ -73,6 +73,9 @@ module Protobuf
         optional :default_value, :string, 7
 
         optional :options, FieldOptions, 8
+
+        ## For oneof members contains the index within the oneof
+        optional :oneof_index, :int32, 9
       end
     end
 
@@ -81,6 +84,14 @@ module Protobuf
 
       contract do
         optional :packed, :bool, 2
+      end
+    end
+
+    struct OneofDescriptorProto
+      include Protobuf::Message
+
+      contract do
+        optional :name, :string, 1
       end
     end
 
@@ -184,6 +195,7 @@ module Protobuf
         repeated :extended,    CodeGeneratorRequest::FieldDescriptorProto, 6
         repeated :nested_type, CodeGeneratorRequest::DescriptorProto,      3
         repeated :enum_type,   CodeGeneratorRequest::EnumDescriptorProto,  4
+        repeated :oneof_decl,  CodeGeneratorRequest::OneofDescriptorProto, 8
       end
     end
 
@@ -340,6 +352,10 @@ module Protobuf
       puts "end"
     end
 
+    def oneof!(oneof_decl, index)
+      puts "oneof #{index}, \"#{oneof_decl.name}\""
+    end
+
     def field!(field, syntax)
       met = case field.label
       when CodeGeneratorRequest::FieldDescriptorProto::Label::LABEL_OPTIONAL
@@ -396,6 +412,7 @@ module Protobuf
           field_desc += ", packed: true" if field.options.not_nil!.packed
         end
       end
+      field_desc += ", oneof_index: #{field.oneof_index}" unless field.oneof_index.nil?
       puts field_desc
     end
 


### PR DESCRIPTION
Given a message:

```
message Foo {
  oneof timestamp {
    int64 created;
    int64 updated;
  }
}
```

Previously the generated classes by crystal-protoc-gen
would allow to set multiple values of the oneof:

```
foo.created = 123
foo.updated = 345

foo.created # => 123
foo.updated # => 345
```

With this patch the sibling oneof-values
will be cleared when one is set:

```
foo.created = 123
foo.updated = 345

foo.created # => nil
foo.updated # => 345
```

Also when deserializing a message that contains
oneofs there was previously no way of knowing
which oneof value is populated.

With this patch we synthesize a new instance
variable by the name of the oneof to contain
the string-name of the member that is populated:

```
foo.created = 123
foo.updated = 345

foo.created # => nil
foo.updated # => 345
foo.timestamp # => "updated"
foo[foo.timestamp] # => 345
```