### PR TITLE
First stab at adding JSON support

### DIFF
--- a/src/protobuf/generator.cr
+++ b/src/protobuf/generator.cr
@@ -276,6 +276,7 @@ module Protobuf
         package_part = package_name ? "for #{package_name}" : ""
         puts "## Generated from #{@file.name} #{package_part}".strip
         puts "require \"protobuf\""
+        puts "require \"json\""
         puts nil
 
         unless @file.dependency.nil?
@@ -335,9 +336,12 @@ module Protobuf
             message_type.field.not_nil!.each { |f| field!(f, syntax) } unless message_type.field.nil?
           end
           puts "end"
+
+          puts nil
+          puts "include JSON::Serializable"
         end
+        puts "end"
       end
-      puts "end"
     end
 
     def field!(field, syntax)


### PR DESCRIPTION
Following the discussion in https://github.com/jeromegn/protobuf.cr/pull/22#issuecomment-881768063
this adds `to_json` and `from_json` to all generated message-classes.

It works surprisingly well for me (even with nested objects etc.)
but the following caveats apply:

* [It won't compile if you have messages that contain fields of type `bytes`](https://github.com/jeromegn/protobuf.cr/pull/22#issuecomment-881611682).
Should probably not be merged or be put behind an env-toggle until that can be addressed.
* I don't know if the output complies with the [Proto3 canonical JSON encoding](https://developers.google.com/protocol-buffers/docs/proto3#json) (it probably doesn't)
