### PR TITLE
Improve enum naming

### DIFF
--- a/src/protobuf/generator.cr
+++ b/src/protobuf/generator.cr
@@ -294,13 +294,17 @@ module Protobuf
       end
     end
 
+    def enum_varname(type_name, enum_name)
+      enum_name.underscore.upcase.lchop(type_name.split("::")[-1].underscore.upcase + "_")
+    end
+
     def enum!(enum_type)
       puts "enum #{enum_type.name}"
       unless enum_type.value.nil?
         indent do
           enum_type.not_nil!.value.not_nil!.each do |ev|
             # Issue 9 - enum constants must start with Capital letter
-            puts "#{ev.name.not_nil!.camelcase} = #{ev.number}"
+            puts "#{enum_varname(enum_type.name.not_nil!, ev.name.not_nil!)} = #{ev.number}"
           end
         end
       end
@@ -369,7 +373,7 @@ module Protobuf
           field.type_name.nil? ?
             field.default_value :
             field.type == CodeGeneratorRequest::FieldDescriptorProto::Type::TYPE_ENUM ?
-              "#{type_name}::#{field.default_value.not_nil!.camelcase}" : # enum
+              "#{type_name}::#{enum_varname(type_name, field.default_value.not_nil!)}" : # enum
               raise Error.new("can't use a default value for non-native / enum types")
         case field.type
         when CodeGeneratorRequest::FieldDescriptorProto::Type::TYPE_DOUBLE

--- a/src/protobuf/generator.cr
+++ b/src/protobuf/generator.cr
@@ -305,6 +305,7 @@ module Protobuf
           enum_type.not_nil!.value.not_nil!.each do |ev|
             # Issue 9 - enum constants must start with Capital letter
             puts "#{enum_varname(enum_type.name.not_nil!, ev.name.not_nil!)} = #{ev.number}"
+            puts "#{ev.name.not_nil!.camelcase} = #{ev.number}"
           end
         end
       end


### PR DESCRIPTION
The protobuf guide [recommends that enums be upper snakecase](https://developers.google.com/protocol-buffers/docs/proto3#enum).

The buf-linter enforces this and additionally requires that
all enum values be prefixed with the enum name, e.g.:

```protobuf
enum ErrorCode {
  ERROR_CODE_UNSPECIFIED = 0;
  ERROR_CODE_NOT_FOUND = 1;
  ERROR_CODE_ACCESS_DENIED = 2;
  ERROR_CODE_NOT_IMPLEMENTED = 3;
}
```

The reasoning is explained here:
https://docs.buf.build/lint-rules#enum_value_prefix

In the past protobuf.cr would unfortunately translate
this style to rather unpleasant crystal identifiers, e.g.:

```crystal
enum ErrorCode
  ERRORCODEUNSPECIFIED = 0
  ERRORCODENOTFOUND = 1
  ERRORCODEACCESSDENIED = 2
  ERRORCODENOTIMPLEMENTED = 3
end
```

This patch enforces upper snakecase for enums and
strips the prefix when it matches the enum-name.

For the above example it produces:

```crystal
enum ErrorCode
  UNSPECIFIED = 0
  NOT_FOUND = 1
  ACCESS_DENIED = 2
  NOT_IMPLEMENTED = 3
end
```