### PR TITLE
Performance improvements

### DIFF
--- a/src/protobuf/buffer.cr
+++ b/src/protobuf/buffer.cr
@@ -154,7 +154,7 @@ module Protobuf
     end
 
     def write_string(str : String)
-      write_bytes(str.encode("UTF-8"))
+      write_bytes(str.to_slice)
     end
 
     def write_fixed32(n : UInt32)


### PR DESCRIPTION
I am using the protobuf library in a project of mine and after profiling I noticed that the majority of time serializing protobufs was occurring in these two places. I don't know if these are general enough changes that should be included in the library but thought I'd open the PR for discussion. 

* `String#encode` is the most expensive one by far. This accounted for a significant percentage of the profile time (~36%). In my use-case the strings are already encoded in UTF-8 and therefore this isn't required. This is also the common case in crystal as all strings by default are UTF-8 encoded. 

* After removing the string encoding in my profile I saw a large number of calls to `Hash#fetch` which stemmed from getting the wire type from `::Protobuf::WIRE_TYPES`. We can move this lookup into the macro itself and have it happen at compile time rather than runtime. 